### PR TITLE
ci(workflows): enable manual triggering of plugin registry validation

### DIFF
--- a/.github/workflows/validate-plugin-registry.yml
+++ b/.github/workflows/validate-plugin-registry.yml
@@ -1,6 +1,8 @@
 name: Validate Plugin Registry
 
 on:
+  # Allow manual trigger from GitHub Actions UI
+  workflow_dispatch:
   pull_request:
     paths:
       - "packages/plugin-registry/registry.json"


### PR DESCRIPTION
Add workflow_dispatch event to the validate-plugin-registry workflow to allow manual execution from GitHub Actions UI.