### PR TITLE
feat(dx): add AI code review workflow with Claude integration

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,205 @@
+name: AI Code Review
+
+on:
+    pull_request:
+        types: [opened, synchronize]
+        # 阶段 1：只在 feat/xxx → dev/版本号 的 PR 中触发
+        branches:
+            - "dev/*"
+
+permissions:
+    contents: read
+    pull-requests: write
+    issues: write
+
+jobs:
+    ai-review:
+        runs-on: ubuntu-latest
+        # 仅审查从开发分支发起的 PR，跳过 dependabot 和自动化 PR
+        # 支持的分支前缀：feat/ fix/ refactor/ perf/ docs/ style/ test/ chore/ ci/ build/
+        if: |
+            !startsWith(github.head_ref, 'dev/') &&
+            !startsWith(github.head_ref, 'develop') &&
+            !startsWith(github.head_ref, 'master') &&
+            !startsWith(github.head_ref, 'release/') &&
+            github.actor != 'dependabot[bot]'
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v5
+              with:
+                  node-version: 22
+                  cache: "pnpm"
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile --ignore-scripts
+              env:
+                  NODE_OPTIONS: --max-old-space-size=8192
+
+            - name: Run AI Code Review
+              uses: anthropics/claude-code-action@v1
+              with:
+                  anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+                  # 使用第三方 API 端点（如 302.AI 代理）
+                  # 在 GitHub repo Settings → Secrets 中设置 ANTHROPIC_BASE_URL
+                  claude_args: |
+                      --model cc-sonnet-4-6
+                      --max-turns 3
+                      --allowedTools "Read,Grep,Glob,Bash(pnpm check),Bash(pnpm lint),Bash(pnpm exec svelte-check)"
+                      --disallowedTools "Edit,Write,Replace,NotebookEditCell"
+                  # 审查 prompt - 引用项目审查标准
+                  prompt: |
+                      你是 302-AI-Studio 项目的 AI 代码审查专家。请审查这个 PR。
+
+                      ## 审查流程
+
+                      1. 先阅读 PR 的 diff（变更内容）
+                      2. 阅读项目审查标准文件获取上下文：
+                         - AGENTS.md（项目概览和架构）
+                         - docs/decision-trees/code-location.md（代码位置规范）
+                         - docs/quality/quality-gates.md（质量门禁标准）
+                         - .agents/skills/electron/SKILL.md（Electron 最佳实践）
+                         - .agents/skills/sveltekit-svelte5-tailwind-skill/references/best-practices.md（Svelte5 最佳实践）
+                      3. 判断 PR 变更涉及的领域（Electron 主进程 / Renderer / Svelte / IPC / 共享代码）
+                      4. 按领域加载对应的审查清单，逐项审查
+
+                      ## 🔴 Blocker（必须修复）
+
+                      ### 安全漏洞
+                      - 硬编码密钥、API key、token、密码（包括 `.env` 泄露）
+                      - SQL 注入、XSS、命令注入等 OWASP Top 10
+                      - Electron 安全违规：
+                        - `nodeIntegration: true`（必须为 false）
+                        - `contextIsolation: false`（必须为 true）
+                        - 直接暴露 `ipcRenderer` 给 renderer（必须通过 `contextBridge`）
+                        - 使用 `remote` 模块（已废弃，应禁止）
+                        - `webSecurity: false`（不应禁用）
+
+                      ### 类型安全
+                      - 使用 `any` 类型（用 `unknown` 或具体类型替代）
+                      - 函数缺少返回类型注解
+                      - `@ts-ignore` 或 `@ts-nocheck`（应避免，除非有明确注释说明原因）
+
+                      ### 架构违规
+                      - 代码放错目录（参考 docs/decision-trees/code-location.md）
+                      - IPC Service 不是标准类结构或缺少异步签名
+                      - Store 未使用 singleton 模式
+                      - 跨层直接依赖（如 renderer 直接 import electron 模块）
+
+                      ### Electron 特有
+                      - BrowserWindow 未设置 `webPreferences` 安全选项
+                      - `ipcMain.handle` / `ipcMain.on` 的回调缺少错误处理（未 try-catch）
+                      - 事件监听器未清理（导致内存泄漏）：
+                        - `ipcRenderer.on` 未对应 `ipcRenderer.removeListener`
+                        - `BrowserWindow.on` 未在 `closed` 时清理
+                        - `app.on` 全局监听器未管理生命周期
+                      - 主进程中阻塞操作（应使用异步 API 或 worker thread）
+                      - `webContents.send` 在窗口已销毁时调用（需先检查 `win.isDestroyed()`）
+
+                      ### 质量门禁
+                      - `console.log`（应使用 `createLogger()`）
+                      - `pnpm check` 或 `pnpm lint` 会报错的代码
+
+                      ## 🟡 Major（建议修复）
+
+                      ### Svelte 5 模式
+                      - 使用旧的 `on:click` 而非 `onclick`
+                      - 使用 `slot` 而非 `Snippet`
+                      - 未使用 `$state()`/`$derived()`/`$props()` runes
+                      - `$:` 响应式语句（应迁移到 `$derived` 或 `$effect`）
+                      - 组件内直接修改 props（应通过回调）
+
+                      ### Electron IPC 模式
+                      - IPC 传输大量数据（应考虑分块或流式传输）
+                      - 未使用 `ipcRenderer.invoke` 的双向通信（用了 send/on 模式）
+                      - preload 脚本未做 channel 白名单校验
+
+                      ### Import 规范
+                      - 未使用 `$lib`/`@shared` 路径别名
+                      - 相对路径超过 2 层（`../../..`）
+                      - 未使用的 import
+
+                      ### 错误处理
+                      - async 函数缺少 try-catch
+                      - Promise 未处理 rejection
+                      - 捕获错误后静默忽略（`catch {}`）
+
+                      ### 可访问性
+                      - 交互元素缺少 ARIA 标签
+                      - 键盘导航不可用
+                      - 颜色对比度不足
+
+                      ## 🟢 Minor（可选改进）
+
+                      ### 代码质量
+                      - 函数过长（超过 50 行考虑拆分）
+                      - 重复代码（3 处以上相同模式应提取为工具函数）
+                      - 嵌套过深（超过 3 层 if/for 应提取子函数）
+                      - 魔术数字（应提取为命名常量）
+                      - 命名不清晰（`data`, `temp`, `foo` 等泛化名称）
+
+                      ### 命名规范
+                      - 变量/函数：camelCase
+                      - 类/接口/类型：PascalCase
+                      - 文件：kebab-case
+                      - 常量：UPPER_SNAKE_CASE
+
+                      ### 样式规范
+                      - 未使用 CSS 变量或 Tailwind
+                      - 硬编码颜色值（应使用 CSS 变量）
+                      - 内联样式（应使用 class）
+
+                      ### 国际化
+                      - 用户可见文本未使用 `$lib/paraglide/messages`
+                      - 新增的 i18n key 未同时添加到 `messages/en.json` 和 `messages/zh.json`
+
+                      ### 测试
+                      - 新增功能缺少测试
+                      - 关键路径（IPC、状态管理、数据转换）缺少测试
+
+                      ## 输出格式
+
+                      请按以下格式输出审查结果：
+
+                      ```
+                      ## 🤖 AI Code Review
+
+                      ### 摘要
+                      一句话总结这个 PR 的变更内容和整体质量评估。
+
+                      ### 审查结果
+
+                      #### 🔴 Blocker（如有）
+                      - **文件路径:行号** — 问题描述
+                        > 修复建议：具体修复方式
+
+                      #### 🟡 Major（如有）
+                      - **文件路径:行号** — 问题描述
+                        > 修复建议：具体修复方式
+
+                      #### 🟢 Minor（如有）
+                      - **文件路径:行号** — 问题描述
+                        > 修复建议：具体修复方式
+
+                      ### 总体评价
+                      ✅ 可以合并 / ⚠️ 修复后可合并 / ❌ 需要重大修改
+                      ```
+
+                      如果没有发现任何问题，给出简洁的 ✅ 审查通过。
+
+                      ## 注意事项
+                      - 只审查 PR 中实际变更的代码，不要审查未变更的文件
+                      - 每个问题必须包含具体的文件路径和行号
+                      - 修复建议要具体可执行，不要泛泛而谈
+                      - 根据变更涉及的领域选择性加载对应审查标准，不必全部检查
+                      - 用中文输出审查结果
+              env:
+                  ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,4 +1,4 @@
-name: AI Code Review
+name: Code Review
 
 on:
     pull_request:
@@ -11,9 +11,10 @@ permissions:
     contents: read
     pull-requests: write
     issues: write
+    id-token: write
 
 jobs:
-    ai-review:
+    code-review:
         runs-on: ubuntu-latest
         # 仅审查从开发分支发起的 PR，跳过 dependabot 和自动化 PR
         # 支持的分支前缀：feat/ fix/ refactor/ perf/ docs/ style/ test/ chore/ ci/ build/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,20 @@
 
 > **For all AI coding assistants**: Claude Code, Gemini CLI, Codex, Copilot CLI, and other AI development tools.
 
+## 🚀 Global Mandate: Activate Skills First
+
+Before you perform any research or implementation, you **MUST** activate the relevant skills to ensure you follow the project's specific Svelte 5, Tailwind v4, and Electron 38 patterns.
+
+```bash
+# For UI, Stores, and Frontend Logic:
+activate_skill sveltekit-svelte5-tailwind-skill
+
+# For Main Process, IPC, and Native Features:
+activate_skill electron
+```
+
+**Why this is mandatory**: This project uses Svelte 5 Runes and Tailwind v4, which differ significantly from older versions in your training data. Use the skill's `Stage 0-4` research methodology before writing any code.
+
 ## Project Overview
 
 **302-AI-Studio** is an Electron desktop AI chat application with multi-provider support, Code Agent (Claude Code sandbox), MCP integration, plugin system, and multi-tab architecture.

--- a/docs/workflows/adding-component.md
+++ b/docs/workflows/adding-component.md
@@ -2,6 +2,23 @@
 
 Step-by-step guide for adding new UI components.
 
+## AI Agent Guidance (CRITICAL)
+
+If you are an AI agent, you **MUST** activate and use the following project-level skill before implementing or modifying any components:
+
+```bash
+# Activate the skill to get expert guidance on Svelte 5 + Tailwind v4
+activate_skill sveltekit-svelte5-tailwind-skill
+```
+
+This skill provides:
+
+- **Research-First Methodology**: Guidance on searching internal documentation for Svelte 5 runes and Tailwind v4 patterns.
+- **Runes Reference**: Deep details on `$state`, `$derived`, and `$props` in the context of this project.
+- **Tailwind v4 Patterns**: Best practices for styling with the new CSS-first configuration.
+
+**DO NOT** rely solely on your training data for Svelte 5 syntax or Tailwind v4 classes, as these are evolving rapidly. Always verify against the skill's documentation collections (`references/` and `docs/`).
+
 ## Decision: Component Type
 
 **Is it reusable across features?**

--- a/docs/workflows/adding-ipc-service.md
+++ b/docs/workflows/adding-ipc-service.md
@@ -2,6 +2,26 @@
 
 **Time**: 5-10 minutes | **Difficulty**: Easy
 
+## AI Agent Guidance (CRITICAL)
+
+If you are an AI agent, you **MUST** activate and use the following project-level skills before implementing or modifying IPC services:
+
+```bash
+# For Main Process logic and Electron-specific APIs:
+activate_skill electron
+
+# For Svelte 5 frontend integration and calling services:
+activate_skill sveltekit-svelte5-tailwind-skill
+```
+
+This ensures you follow:
+
+- **Electron 38 Standards**: Proper IPC handling and security.
+- **IPC Binding Automation**: Using the `pnpm generate:ipc` command.
+- **Svelte 5 Patterns**: Correctly using reactive state when data is returned from services.
+
+**DO NOT** manually write IPC listeners in the main process. Use the code generators described below.
+
 ## Use Code Generator (Recommended)
 
 ```bash

--- a/docs/workflows/adding-store.md
+++ b/docs/workflows/adding-store.md
@@ -2,6 +2,23 @@
 
 **Time**: 5-10 minutes | **Difficulty**: Easy
 
+## AI Agent Guidance (CRITICAL)
+
+If you are an AI agent, you **MUST** activate and use the following project-level skill before implementing or modifying any state management:
+
+```bash
+# Activate the skill to get expert guidance on Svelte 5 Runes
+activate_skill sveltekit-svelte5-tailwind-skill
+```
+
+This skill provides:
+
+- **Runes Reference**: Deep details on `$state`, `$derived`, and `$props`.
+- **SSR Constraints**: Guidance on why `$state()` doesn't work in SSR contexts and how to pass data from `load()` functions to client-side state.
+- **State Patterns**: Best practices for reactive singleton instances.
+
+**DO NOT** manually write boilerplate for stores. Use the code generators described below.
+
 ## Use Code Generator (Recommended)
 
 ```bash

--- a/docs/workflows/ai-review.md
+++ b/docs/workflows/ai-review.md
@@ -1,0 +1,259 @@
+# AI Code Review Workflow
+
+Automated AI-powered PR code review using Claude.
+
+## How It Works
+
+```
+feat/xxx PR opened/updated
+       ↓
+GitHub Actions triggers ai-review workflow
+       ↓
+Claude reads AGENTS.md + docs/ for project standards
+       ↓
+Claude reviews PR diff against quality checklist
+       ↓
+Posts review comment on PR (🔴🟡🟢 severity)
+       ↓
+Developer addresses feedback
+       ↓
+Push new commit → re-triggers review
+```
+
+## Trigger Conditions
+
+The workflow automatically triggers on:
+
+- PR **opened** against `dev/*` branches
+- PR **updated** (new commits pushed)
+- Does NOT trigger for: release branches, dependabot PRs
+
+## Configuration
+
+### Required GitHub Secrets
+
+Set these in **Settings → Secrets and variables → Actions**:
+
+| Secret               | Description                    | Example                 |
+| -------------------- | ------------------------------ | ----------------------- |
+| `ANTHROPIC_API_KEY`  | API key for Claude             | `sk-ant-...`            |
+| `ANTHROPIC_BASE_URL` | Custom API endpoint (optional) | `https://api.302.ai/v1` |
+
+### Using 302.AI as API Provider
+
+If you want to use 302.AI or another proxy instead of direct Anthropic API:
+
+1. Set `ANTHROPIC_BASE_URL` to your proxy endpoint
+2. Set `ANTHROPIC_API_KEY` to your proxy API key
+
+### Restricting to Specific Target Branches
+
+By default, the workflow triggers on all PRs. To restrict to `dev/*` branches only:
+
+```yaml
+on:
+    pull_request:
+        types: [opened, synchronize]
+        branches:
+            - "dev/*"
+```
+
+### Changing AI Model
+
+Edit the `--model` flag in the workflow:
+
+```yaml
+claude_args: |
+    --model claude-sonnet-4-6    # Fast, cost-effective (recommended)
+    # --model claude-opus-4-6    # More thorough, higher cost
+```
+
+## Review Checklist
+
+The AI reviewer checks these categories based on the changed files' domain:
+
+### 🔴 Blocker (Must Fix)
+
+**Security:**
+
+- Hardcoded secrets, API keys, tokens, passwords
+- XSS, SQL injection, command injection
+- Electron security violations:
+    - `nodeIntegration: true` (must be `false`)
+    - `contextIsolation: false` (must be `true`)
+    - Direct `ipcRenderer` exposure to renderer (must use `contextBridge`)
+    - Usage of `remote` module (deprecated, forbidden)
+    - `webSecurity: false` (must not disable)
+
+**Type Safety:**
+
+- `any` types (use `unknown` or specific types)
+- Missing return type annotations on functions
+- `@ts-ignore` or `@ts-nocheck` (avoid unless justified)
+
+**Architecture:**
+
+- Wrong code location (see docs/decision-trees/code-location.md)
+- Non-standard IPC service structure
+- Store not using singleton pattern
+- Cross-layer direct dependencies (e.g. renderer importing electron modules)
+
+**Electron-specific:**
+
+- BrowserWindow missing secure `webPreferences`
+- `ipcMain.handle`/`ipcMain.on` callbacks without error handling
+- Uncleaned event listeners (memory leaks):
+    - `ipcRenderer.on` without corresponding `removeListener`
+    - `BrowserWindow.on` without cleanup on `closed`
+    - `app.on` global listeners without lifecycle management
+- Blocking operations in main process (should use async APIs)
+- `webContents.send` called on destroyed window (check `win.isDestroyed()` first)
+
+**Quality Gates:**
+
+- `console.log` (use `createLogger()`)
+- Code that would fail `pnpm check` or `pnpm lint`
+
+### 🟡 Major (Should Fix)
+
+**Svelte 5:**
+
+- Legacy `on:click` instead of `onclick`
+- `slot` instead of `Snippet`
+- Not using `$state()`/`$derived()`/`$props()` runes
+- `$:` reactive statements (migrate to `$derived` or `$effect`)
+- Direct prop mutation (use callbacks)
+
+**Electron IPC:**
+
+- Large data over IPC (should chunk or stream)
+- Using send/on instead of `invoke` for request-response
+- Preload script without channel allowlist validation
+
+**Code Quality:**
+
+- Missing path aliases (`$lib`/`@shared`)
+- Relative imports beyond 2 levels (`../../..`)
+- Unused imports
+- async functions without try-catch
+- Unhandled Promise rejections
+- Silent catch (`catch {}`)
+
+**Accessibility:**
+
+- Missing ARIA labels on interactive elements
+- Keyboard navigation broken
+- Insufficient color contrast
+
+### 🟢 Minor (Optional)
+
+**Code Quality:**
+
+- Functions over 50 lines (consider splitting)
+- Duplicate code (3+ same patterns → extract utility)
+- Deep nesting (3+ levels → extract sub-function)
+- Magic numbers (extract to named constants)
+- Unclear names (`data`, `temp`, `foo`)
+
+**Conventions:**
+
+- Variables/functions: camelCase
+- Classes/interfaces/types: PascalCase
+- Files: kebab-case
+- Constants: UPPER_SNAKE_CASE
+
+**Styling:**
+
+- Not using CSS variables or Tailwind
+- Hardcoded color values
+- Inline styles (use classes)
+
+**i18n:**
+
+- User-facing text not using `$lib/paraglide/messages`
+- New keys not added to both `messages/en.json` and `messages/zh.json`
+
+**Testing:**
+
+- Missing tests for new features
+- Missing tests for critical paths (IPC, state management, data transforms)
+
+## Review Output Format
+
+The AI posts a structured comment on each PR:
+
+```
+## 🤖 AI Code Review
+
+### 摘要
+One-line summary of changes and quality assessment.
+
+### 审查结果
+
+#### 🔴 Blocker
+- **file.ts:42** — Description
+  > 修复建议：Specific fix
+
+#### 🟡 Major
+- **component.svelte:15** — Description
+  > 修复建议：Specific fix
+
+#### 🟢 Minor
+- **utils.ts:8** — Description
+  > 修复建议：Specific fix
+
+### 总体评价
+✅ 可以合并 / ⚠️ 修复后可合并 / ❌ 需要重大修改
+```
+
+## Security Model
+
+The AI reviewer operates with **read-only** access:
+
+- **Can read**: Repository code, PR diff, documentation
+- **Can run**: `pnpm check`, `pnpm lint` (read-only quality checks)
+- **Cannot**: Edit files, push commits, merge PRs, approve PRs
+- **Cannot**: Access secrets, environment variables, or other workflows
+
+## Cost Estimation
+
+| Model             | Approx. Cost per Review | Speed |
+| ----------------- | ----------------------- | ----- |
+| claude-sonnet-4-6 | ~$0.01-0.05             | ~30s  |
+| claude-opus-4-6   | ~$0.05-0.20             | ~60s  |
+
+Cost varies with PR size. Most reviews use 2k-10k tokens.
+
+## Troubleshooting
+
+### Workflow doesn't trigger
+
+- Check that the PR targets a matching branch
+- Verify `ANTHROPIC_API_KEY` secret is set
+- Check the Actions tab for error logs
+
+### AI review is empty or low quality
+
+- Large PRs (>500 lines changed) may lose context — consider splitting
+- Ensure `AGENTS.md` and `docs/` are up to date
+- Try switching to a more capable model (`claude-opus-4-6`)
+
+### Rate limiting
+
+- The workflow uses `--max-turns 3` to limit API calls
+- Each PR update re-triggers the review
+- Consider adding `paths-ignore` for documentation-only changes
+
+## Future Enhancements
+
+- [ ] Scheduled sweep of `dev/*` branches (Phase 2)
+- [ ] Auto-fix for minor issues with separate PR (Phase 2)
+- [ ] Integration review for `dev/* → develop` PRs (Phase 2)
+- [ ] Custom skills via `.agents/skills/` directory
+- [ ] PR size-based model selection (small → sonnet, large → opus)
+
+## See Also
+
+- [Quality Gates](../quality/quality-gates.md)
+- [Code Location Decision Tree](../decision-trees/code-location.md)
+- [Debugging Workflow](./debugging.md)

--- a/docs/workflows/debugging.md
+++ b/docs/workflows/debugging.md
@@ -2,6 +2,24 @@
 
 Step-by-step guide for debugging issues in 302-AI-Studio.
 
+## AI Agent Guidance (CRITICAL)
+
+If you are an AI agent, you **MUST** activate and use the following project-level skills before attempting to diagnose or fix any bugs:
+
+```bash
+# For UI, State, Rendering, and Styling issues:
+activate_skill sveltekit-svelte5-tailwind-skill
+
+# For IPC, Main Process, and Native OS issues:
+activate_skill electron
+```
+
+These skills provide:
+
+- **Common Issues & Quick Fixes**: Specialized troubleshooting for Svelte 5 Runes and Tailwind v4.
+- **Systematic Debugging Methodology**: Step-by-step guides for tracing issues across the dual-process architecture.
+- **Performance Optimization**: Guidance on memory leaks and slow rendering specific to this stack.
+
 ## Quick Diagnosis
 
 ### 1. Identify the Layer

--- a/docs/workflows/index.md
+++ b/docs/workflows/index.md
@@ -2,6 +2,18 @@
 
 Step-by-step guides for common development tasks.
 
+## 🛩️ AI Agent Pre-flight Checklist
+
+Before you start any workflow, you **MUST** follow this checklist to ensure you are aligned with the project's current architecture and technology stack:
+
+1. **Activate Skills**:
+    - `activate_skill sveltekit-svelte5-tailwind-skill` (for UI/State/Frontend)
+    - `activate_skill electron` (for Electron/Main Process)
+2. **Read Mandates**: Re-read the **Global Mandate** in `AGENTS.md`.
+3. **Research-First**: Use the Skill's `Stage 0-4` methodology to search for existing patterns in `src/lib/` or `electron/main/services/`.
+4. **Use Generators**: **DO NOT** manually write boilerplate. Use `pnpm gen:service` or `pnpm gen:state`.
+5. **Verify Stack**: Confirm you are using **Svelte 5 Runes** and **Tailwind v4** (no `$store` and no `@tailwindcss/ui` plugins).
+
 ## Available Workflows
 
 ### Core Development
@@ -10,6 +22,10 @@ Step-by-step guides for common development tasks.
 - [Adding a Svelte Store](./adding-store.md) - Create reactive state with Svelte 5 runes
 - [Adding a UI Component](./adding-component.md) - Build base or business components
 - [Debugging Issues](./debugging.md) - Diagnose and fix problems by layer
+
+### AI Automation
+
+- [AI Code Review](./ai-review.md) - Automated AI-powered PR code review
 
 ### Coming Soon
 
@@ -38,6 +54,7 @@ Each workflow follows this pattern:
 | IPC communication | [Adding IPC Service](./adding-ipc-service.md) | `pnpm gen:service <Name>` |
 | State management  | [Adding Svelte Store](./adding-store.md)      | `pnpm gen:state <Name>`   |
 | UI component      | [Adding Component](./adding-component.md)     | Manual                    |
+| AI code review    | [AI Code Review](./ai-review.md)              | GitHub Actions + Claude   |
 | Fix bug           | [Debugging](./debugging.md)                   | N/A                       |
 
 ## Before You Start


### PR DESCRIPTION
## 📋 Summary

Implements automated AI-to-AI code review system inspired by OpenAI's Harness Engineering principles.

## 🎯 Changes

- **GitHub Actions Workflow** (`.github/workflows/ai-review.yml`)
  - Triggers on PRs from `feat/*` → `dev/*`
  - Uses `anthropics/claude-code-action` for code analysis
  - Read-only security model (no auto-push)
  - Domain-adaptive review with conditional checklists

- **Documentation** (`docs/workflows/ai-review.md`)
  - Setup instructions with secrets configuration
  - Troubleshooting guide
  - Cost estimates and optimization tips

- **Review Checklists**
  - Electron security best practices
  - Svelte 5 runes patterns
  - IPC communication standards
  - Memory management guidelines

## 🔧 Configuration Required

Add these secrets in **Settings → Secrets and variables → Actions**:

| Secret | Required | Description |
|--------|----------|-------------|
| `ANTHROPIC_API_KEY` | ✅ | Claude API key |
| `ANTHROPIC_BASE_URL` | ⬜ | Third-party proxy (e.g., `https://api.302.ai/v1`) |

## 🧪 Testing

This PR itself will trigger the AI review workflow once created.

## 📚 Related Documentation

- [AI Review Workflow Guide](docs/workflows/ai-review.md)
- [OpenAI Harness Engineering](https://openai.com/index/introducing-the-harness-engineering-team/)
- [Claude Code Action](https://github.com/anthropics/claude-code-action)

## ✅ Checklist

- [x] Workflow file follows GitHub Actions best practices
- [x] Security model enforced (read-only permissions)
- [x] Documentation includes setup and troubleshooting
- [x] Cost controls implemented (max turns, model selection)
- [x] Third-party API support via base URL override