### PR TITLE
refactor(cloud-mode): extract error response checking into shared helper

### DIFF
--- a/electron/main/apis/cloud-mode.ts
+++ b/electron/main/apis/cloud-mode.ts
@@ -14,7 +14,11 @@ import {
 	restartDockerResponseSchema,
 	sandboxHealthResponseSchema,
 } from "@shared/storage/cloud-mode";
-import { CloudModeApiError, parseCloudModeError } from "@shared/storage/cloud-mode-errors";
+import {
+	CloudModeApiError,
+	parseCloudModeError,
+	checkErrorResponse,
+} from "@shared/storage/cloud-mode-errors";
 import { type } from "arktype";
 
 import { _302AIKy } from "./core/_302ai-ky";
@@ -27,16 +31,7 @@ export async function listInstances(): Promise<ListInstancesResponse> {
 	try {
 		const response = await _302AIKy.get("302/swas/instances").json();
 
-		// Check for error response
-		if (response && typeof response === "object" && "success" in response) {
-			if (response.success === false && "error" in response) {
-				const errorObj = response.error as { code?: string; message?: string };
-				throw new CloudModeApiError(
-					errorObj.code || "SWAS_LIST_INSTANCE_FAILED",
-					errorObj.message || "Failed to list instances",
-				);
-			}
-		}
+		checkErrorResponse(response, "SWAS_LIST_INSTANCE_FAILED", "Failed to list instances");
 
 		const validated = listInstancesResponseSchema(response);
 		if (validated instanceof type.errors) {
@@ -66,16 +61,7 @@ export async function restartDocker(request: RestartDockerRequest): Promise<Rest
 			.post("302/swas/instances/openclaw/restart", { json: requestBody })
 			.json();
 
-		// Check for error response
-		if (response && typeof response === "object" && "success" in response) {
-			if (response.success === false && "error" in response) {
-				const errorObj = response.error as { code?: string; message?: string };
-				throw new CloudModeApiError(
-					errorObj.code || "SWAS_REBOOT_FAILED",
-					errorObj.message || "Failed to restart docker",
-				);
-			}
-		}
+		checkErrorResponse(response, "SWAS_REBOOT_FAILED", "Failed to restart docker");
 
 		const validated = restartDockerResponseSchema(response);
 		if (validated instanceof type.errors) {
@@ -105,16 +91,7 @@ export async function readInstanceFiles(request: ReadFilesRequest): Promise<Read
 			.post("302/swas/instances/files/read", { json: requestBody })
 			.json();
 
-		// Check for error response
-		if (response && typeof response === "object" && "success" in response) {
-			if (response.success === false && "error" in response) {
-				const errorObj = response.error as { code?: string; message?: string };
-				throw new CloudModeApiError(
-					errorObj.code || "UNKNOWN_ERROR",
-					errorObj.message || "Failed to read files",
-				);
-			}
-		}
+		checkErrorResponse(response, "UNKNOWN_ERROR", "Failed to read files");
 
 		const validated = readFilesResponseSchema(response);
 		if (validated instanceof type.errors) {

--- a/electron/main/services/logger-service/index.ts
+++ b/electron/main/services/logger-service/index.ts
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { isDev } from "@electron/main/constants";
 import type { LogCategory, LogLevel } from "@shared/logger/types";
+import archiver from "archiver";
 import type { IpcMainInvokeEvent } from "electron";
 import { app, dialog } from "electron";
 import type { LogFunctions } from "electron-log";
 import log from "electron-log";
 import { createWriteStream, existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import { join } from "path";
-import archiver from "archiver";
 import { schedulerService } from "../scheduler-service";
 
 // electron-log LogFunctions doesn't include 'fatal', map it to 'error'
@@ -79,7 +79,15 @@ export class LoggerService {
 				const pad = (n: number, len = 2) => String(n).padStart(len, "0");
 				const ts = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(d.getMilliseconds(), 3)}`;
 				const text = data
-					.map((item: any) => (typeof item === "string" ? item : String(item)))
+					.map((item: any) => {
+						if (typeof item === "string") return item;
+						if (item instanceof Error) return item.stack || item.message;
+						try {
+							return JSON.stringify(item);
+						} catch (_e) {
+							return String(item);
+						}
+					})
 					.join(" ");
 				const c = ANSI[level] || "";
 				return [`${c}[${ts}] [${level}]${R} ${text}`];

--- a/src/lib/api/cloud-mode/base-apis.ts
+++ b/src/lib/api/cloud-mode/base-apis.ts
@@ -1,4 +1,8 @@
-import { CloudModeApiError, parseCloudModeError } from "@shared/storage/cloud-mode-errors";
+import {
+	CloudModeApiError,
+	parseCloudModeError,
+	checkErrorResponse,
+} from "@shared/storage/cloud-mode-errors";
 import {
 	createInstanceRequestSchema,
 	createInstanceResponseSchema,
@@ -104,16 +108,7 @@ export async function createInstance(
 
 		const response = await _302AIKy.post("302/swas/instances", { json: requestBody }).json();
 
-		// Check for error response
-		if (response && typeof response === "object" && "success" in response) {
-			if (response.success === false && "error" in response) {
-				const errorObj = response.error as { code?: string; message?: string };
-				throw new CloudModeApiError(
-					errorObj.code || "CREATE_INSTANCE_FAILED",
-					errorObj.message || "Failed to create instance",
-				);
-			}
-		}
+		checkErrorResponse(response, "CREATE_INSTANCE_FAILED", "Failed to create instance");
 
 		const validated = createInstanceResponseSchema(response);
 		if (validated instanceof type.errors) {
@@ -143,16 +138,7 @@ export async function initInstance(request: InitInstanceRequest): Promise<InitIn
 			.post("302/swas/instances/init", { json: requestBody })
 			.json();
 
-		// Check for error response
-		if (response && typeof response === "object" && "success" in response) {
-			if (response.success === false && "error" in response) {
-				const errorObj = response.error as { code?: string; message?: string };
-				throw new CloudModeApiError(
-					errorObj.code || "INIT_INSTANCE_FAILED",
-					errorObj.message || "Failed to initialize instance",
-				);
-			}
-		}
+		checkErrorResponse(response, "INIT_INSTANCE_FAILED", "Failed to initialize instance");
 
 		const validated = initInstanceResponseSchema(response);
 		if (validated instanceof type.errors) {
@@ -205,16 +191,7 @@ export async function restartDocker(request: RestartDockerRequest): Promise<Rest
 			.post("302/swas/instances/openclaw/restart", { json: requestBody })
 			.json();
 
-		// Check for error response
-		if (response && typeof response === "object" && "success" in response) {
-			if (response.success === false && "error" in response) {
-				const errorObj = response.error as { code?: string; message?: string };
-				throw new CloudModeApiError(
-					errorObj.code || "SWAS_REBOOT_FAILED",
-					errorObj.message || "Failed to restart docker",
-				);
-			}
-		}
+		checkErrorResponse(response, "SWAS_REBOOT_FAILED", "Failed to restart docker");
 
 		const validated = restartDockerResponseSchema(response);
 		if (validated instanceof type.errors) {
@@ -246,16 +223,7 @@ export async function updateAutoRenew(
 			.post("302/swas/instances/auto-renew", { json: requestBody })
 			.json();
 
-		// Check for error response
-		if (response && typeof response === "object" && "success" in response) {
-			if (response.success === false && "error" in response) {
-				const errorObj = response.error as { code?: string; message?: string };
-				throw new CloudModeApiError(
-					errorObj.code || "UPDATE_AUTO_RENEW_FAILED",
-					errorObj.message || "Failed to update auto-renew",
-				);
-			}
-		}
+		checkErrorResponse(response, "UPDATE_AUTO_RENEW_FAILED", "Failed to update auto-renew");
 
 		const validated = updateAutoRenewResponseSchema(response);
 		if (validated instanceof type.errors) {
@@ -286,16 +254,7 @@ export async function manualRenew(request: ManualRenewRequest): Promise<ManualRe
 			.post("302/swas/instances/manual-renew", { json: requestBody })
 			.json();
 
-		// Check for error response
-		if (response && typeof response === "object" && "success" in response) {
-			if (response.success === false && "error" in response) {
-				const errorObj = response.error as { code?: string; message?: string };
-				throw new CloudModeApiError(
-					errorObj.code || "MANUAL_RENEW_FAILED",
-					errorObj.message || "Failed to manually renew",
-				);
-			}
-		}
+		checkErrorResponse(response, "MANUAL_RENEW_FAILED", "Failed to manually renew");
 
 		const validated = manualRenewResponseSchema(response);
 		if (validated instanceof type.errors) {
@@ -360,16 +319,7 @@ export async function getManualRenewCharge(
 			.get(`302/swas/instances/manual-renew/charges?page=${page}&page_size=${pageSize}`)
 			.json();
 
-		// Check for error response
-		if (response && typeof response === "object" && "success" in response) {
-			if (response.success === false && "error" in response) {
-				const errorObj = response.error as { code?: string; message?: string };
-				throw new CloudModeApiError(
-					errorObj.code || "UNKNOWN_ERROR",
-					errorObj.message || "Failed to get manual renew charges",
-				);
-			}
-		}
+		checkErrorResponse(response, "UNKNOWN_ERROR", "Failed to get manual renew charges");
 
 		const validated = getManualRenewChargeResponseSchema(response);
 		if (validated instanceof type.errors) {
@@ -401,16 +351,7 @@ export async function rebootInstance(
 			.post("302/swas/instances/reboot", { json: requestBody })
 			.json();
 
-		// Check for error response
-		if (response && typeof response === "object" && "success" in response) {
-			if (response.success === false && "error" in response) {
-				const errorObj = response.error as { code?: string; message?: string };
-				throw new CloudModeApiError(
-					errorObj.code || "SWAS_REBOOT_FAILED",
-					errorObj.message || "Failed to reboot instance",
-				);
-			}
-		}
+		checkErrorResponse(response, "SWAS_REBOOT_FAILED", "Failed to reboot instance");
 
 		const validated = rebootInstanceResponseSchema(response);
 		if (validated instanceof type.errors) {
@@ -443,16 +384,7 @@ export async function updateInstanceAutoRenew(
 			json: requestBody,
 		}).json();
 
-		// Check for error response
-		if (response && typeof response === "object" && "success" in response) {
-			if (response.success === false && "error" in response) {
-				const errorObj = response.error as { code?: string; message?: string };
-				throw new CloudModeApiError(
-					errorObj.code || "UPDATE_AUTO_RENEW_FAILED",
-					errorObj.message || "Failed to update auto-renew",
-				);
-			}
-		}
+		checkErrorResponse(response, "UPDATE_AUTO_RENEW_FAILED", "Failed to update auto-renew");
 
 		const validated = updateInstanceAutoRenewResponseSchema(response);
 		if (validated instanceof type.errors) {
@@ -481,16 +413,7 @@ export async function readInstanceFiles(request: ReadFilesRequest): Promise<Read
 			.post("302/swas/instances/files/read", { json: requestBody })
 			.json();
 
-		// Check for error response
-		if (response && typeof response === "object" && "success" in response) {
-			if (response.success === false && "error" in response) {
-				const errorObj = response.error as { code?: string; message?: string };
-				throw new CloudModeApiError(
-					errorObj.code || "UNKNOWN_ERROR",
-					errorObj.message || "Failed to read files",
-				);
-			}
-		}
+		checkErrorResponse(response, "UNKNOWN_ERROR", "Failed to read files");
 
 		const validated = readFilesResponseSchema(response);
 		if (validated instanceof type.errors) {
@@ -519,16 +442,7 @@ export async function writeInstanceFiles(request: WriteFilesRequest): Promise<Wr
 			.post("302/swas/instances/files/write", { json: requestBody })
 			.json();
 
-		// Check for error response
-		if (response && typeof response === "object" && "success" in response) {
-			if (response.success === false && "error" in response) {
-				const errorObj = response.error as { code?: string; message?: string };
-				throw new CloudModeApiError(
-					errorObj.code || "UNKNOWN_ERROR",
-					errorObj.message || "Failed to write files",
-				);
-			}
-		}
+		checkErrorResponse(response, "UNKNOWN_ERROR", "Failed to write files");
 
 		const validated = writeFilesResponseSchema(response);
 		if (validated instanceof type.errors) {
@@ -559,16 +473,7 @@ export async function execInstanceCommand(
 			.post("302/swas/instances/commands/exec", { json: requestBody })
 			.json();
 
-		// Check for error response
-		if (response && typeof response === "object" && "success" in response) {
-			if (response.success === false && "error" in response) {
-				const errorObj = response.error as { code?: string; message?: string };
-				throw new CloudModeApiError(
-					errorObj.code || "UNKNOWN_ERROR",
-					errorObj.message || "Failed to execute command",
-				);
-			}
-		}
+		checkErrorResponse(response, "UNKNOWN_ERROR", "Failed to execute command");
 
 		const validated = execCommandResponseSchema(response);
 		if (validated instanceof type.errors) {

--- a/src/lib/components/buss/mcp-import-modal/index.ts
+++ b/src/lib/components/buss/mcp-import-modal/index.ts
@@ -1,4 +1,4 @@
 import Root from "./mcp-import-modal.svelte";
 
-export { Root, Root as McpImportModal };
-export type { Props as McpImportModalProps, ImportData } from "./mcp-import-modal.svelte";
+export type { ImportData, Props as McpImportModalProps } from "./mcp-import-modal.svelte";
+export { Root as McpImportModal, Root };

--- a/src/lib/components/buss/model-dialog/index.ts
+++ b/src/lib/components/buss/model-dialog/index.ts
@@ -1,5 +1,5 @@
 import Root from "./model-dialog.svelte";
 
-export { Root, Root as ModelDialog };
+export { Root as ModelDialog, Root };
 
 export type { Props as ModelDialogProps } from "./model-dialog.svelte";

--- a/src/lib/components/buss/skill-list/index.ts
+++ b/src/lib/components/buss/skill-list/index.ts
@@ -1,5 +1,5 @@
 export { default as SkillCard } from "./skill-card.svelte";
 export { default as SkillCreateDialog } from "./skill-create-dialog.svelte";
+export type { SkillCreateMethod } from "./skill-create-dialog.svelte";
 export { default as SkillDetailDialog } from "./skill-detail-dialog.svelte";
 export { default as SkillList } from "./skill-list.svelte";
-export type { SkillCreateMethod } from "./skill-create-dialog.svelte";

--- a/src/shared/storage/cloud-mode-errors.ts
+++ b/src/shared/storage/cloud-mode-errors.ts
@@ -87,6 +87,31 @@ export class CloudModeApiError extends Error {
 }
 
 /**
+ * Check if response contains an error and throw CloudModeApiError if so
+ * This helper reduces code duplication across API functions
+ *
+ * @param response - API response to check
+ * @param defaultErrorCode - Error code to use if not provided in response
+ * @param defaultMessage - Error message to use if not provided in response
+ * @throws {CloudModeApiError} If response indicates an error
+ */
+export function checkErrorResponse(
+	response: unknown,
+	defaultErrorCode: string,
+	defaultMessage: string,
+): void {
+	if (response && typeof response === "object" && "success" in response) {
+		if (response.success === false && "error" in response) {
+			const errorObj = response.error as { code?: string; message?: string };
+			throw new CloudModeApiError(
+				errorObj.code || defaultErrorCode,
+				errorObj.message || defaultMessage,
+			);
+		}
+	}
+}
+
+/**
  * Parse error response from Cloud Mode API
  * Handles multiple error formats:
  * 1. CloudModeApiError (already parsed)


### PR DESCRIPTION
## Summary
- Extract `checkErrorResponse()` helper function to reduce code duplication
- Apply helper to 10+ API functions across main process and renderer
- Improve logger service serialization for Error objects (use stack trace)
- Reorder component exports for consistency (types before values)

## Changes
**Refactoring**
- ~120 lines of duplicate error-checking code replaced with single helper function
- No functionality changes - pure refactoring

**Improved Logging**
- Error objects now properly serialize to show stack traces
- Prevents `[object Object]` in logs

**Code Quality**
- Consistent export ordering across business components
- Follows project's established patterns

## Test plan
- [x] All quality checks pass (lint, format, type-check)
- [x] No breaking changes to API surface
- [x] Error handling behavior unchanged
- [x] Manual testing of cloud mode features

## Files changed
- `electron/main/apis/cloud-mode.ts`
- `electron/main/services/logger-service/index.ts`
- `src/lib/api/cloud-mode/base-apis.ts`
- `src/lib/components/buss/mcp-import-modal/index.ts`
- `src/lib/components/buss/model-dialog/index.ts`
- `src/lib/components/buss/skill-list/index.ts`
- `src/shared/storage/cloud-mode-errors.ts`