### PR TITLE
fix(cloud-platform): close restart machine and openclaw dialogs after action

### DIFF
--- a/electron/main/services/cloud-mode-sevice/index.ts
+++ b/electron/main/services/cloud-mode-sevice/index.ts
@@ -28,7 +28,7 @@ export class CloudModeService {
 	/**
 	 * Check if local instance exists, decide whether to start polling
 	 */
-	private async maybeStartPolling(): Promise<void> {
+	private async maybeStartPolling(mode?: "fast" | "normal"): Promise<void> {
 		const [error, instance] = await attemptAsync(() => cloudModeStorage.getCloudModeInstance());
 
 		if (error || isNull(instance)) {
@@ -38,7 +38,9 @@ export class CloudModeService {
 
 		// Start polling if instance name exists (even if expired, need to monitor state changes)
 		if (instance.instanceName) {
-			this.startPolling();
+			// If mode isn't explicitly provided, default to fast if not running, normal if running
+			const resolvedMode = mode || (instance.status !== "running" ? "fast" : "normal");
+			this.startPolling(resolvedMode);
 			logger.info("[CloudModeService] Polling started for instance:", instance.instanceName);
 		}
 	}
@@ -46,10 +48,23 @@ export class CloudModeService {
 	/**
 	 * Start two scheduled tasks (addTask has internal deduplication, no need to worry about duplicate calls)
 	 */
-	private startPolling(): void {
-		// Sync instance info every 5 minutes
-		schedulerService.addTask("cloud-mode-instance-sync", "0 */5 * * * *", async () => {
-			await this.syncCloudInstanceToLocal();
+	private startPolling(mode: "fast" | "normal" = "normal"): void {
+		// Sync instance info: 20s if fast, 5m if normal
+		const instanceSyncCron = mode === "fast" ? "*/20 * * * * *" : "0 */5 * * * *";
+
+		schedulerService.addTask("cloud-mode-instance-sync", instanceSyncCron, async () => {
+			const [error, instances] = await attemptAsync(() => this.syncCloudInstanceToLocal());
+
+			// If we are in fast polling mode and the instance reached "running", revert to normal 5m polling
+			if (mode === "fast" && !error && instances && instances.length > 0) {
+				if (instances[0].status === "running") {
+					logger.info(
+						"[CloudModeService] Instance is running. Reverting to normal polling.",
+					);
+					this.startPolling("normal");
+				}
+			}
+
 			// Check if polling should stop after sync
 			await this.checkAndStopPolling();
 		});
@@ -161,6 +176,7 @@ export class CloudModeService {
 	 * IPC: Sync + Start polling (called by renderer after instance operations)
 	 */
 	public async syncAndStartPollingByIpc(_event: IpcMainInvokeEvent): Promise<{ isOk: boolean }> {
+		// Do a normal sync first (can show errors if it fails immediately after operation)
 		const [syncError] = await attemptAsync(() => this.syncCloudInstanceToLocal());
 
 		if (syncError) {
@@ -168,7 +184,8 @@ export class CloudModeService {
 			return { isOk: false };
 		}
 
-		await this.maybeStartPolling();
+		// Start fast polling
+		await this.maybeStartPolling("fast");
 		return { isOk: true };
 	}
 

--- a/electron/main/services/storage-service/cloud-mode/cloud-mode-storage.ts
+++ b/electron/main/services/storage-service/cloud-mode/cloud-mode-storage.ts
@@ -11,7 +11,7 @@ export const getDefaultInstanceInfo = (): InstanceInfo => ({
 	publicIp: "",
 	createdAt: "",
 	expiredAt: "",
-	expired: false,
+	expired: true,
 	apiPort: 0,
 	ocPort: 0,
 	status: "disabled",

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,7 +1,7 @@
 import type { ChatMessage } from "$lib/stores/chat-state.svelte";
 import type { ElectronAPI } from "@electron-toolkit/preload";
-import type { CodeAgentConfigMetadata, CodeAgentMetadata } from "@shared/storage/code-agent";
 import type { SandboxHealthResponse } from "@shared/storage/cloud-mode";
+import type { CodeAgentConfigMetadata, CodeAgentMetadata } from "@shared/storage/code-agent";
 import type {
 	BroadcastEventData,
 	OpenClawWeixinLoginMsg,

--- a/src/lib/api/sandbox-session.ts
+++ b/src/lib/api/sandbox-session.ts
@@ -171,12 +171,12 @@ export async function deleteSession(request: DeleteSessionRequest): Promise<Dele
 }
 
 /**
- * Delete a local session (always uses local ky instance, no global state dependency).
+ * Delete a local or cloud session (always uses local ky instance, no global state dependency).
  * Used by local-specific code paths.
  *
- * 删除本地对话（始终使用本地 ky 实例，不依赖全局状态）
+ * 删除本地或云端对话（始终使用本地 ky 实例，不依赖全局状态）
  */
-export async function deleteLocalSession(
+export async function deleteLocalOrCloudSession(
 	sessionId: string,
 	mode: CodeAgentType,
 ): Promise<DeleteSessionResult> {
@@ -206,11 +206,11 @@ export async function deleteLocalSession(
 }
 
 /**
- * List local sessions (always uses local ky instance, no global state dependency).
+ * List local or cloud sessions (always uses local ky instance, no global state dependency).
  *
- * 列出本地会话（始终使用本地 ky 实例）
+ * 列出本地或云端会话（始终使用本地 ky 实例）
  */
-export async function listLocalSessions(
+export async function listLocalOrCloudSessions(
 	mode: CodeAgentType,
 ): Promise<ListLocalClaudeCodeSessionsResponse> {
 	try {
@@ -227,7 +227,7 @@ export async function listLocalSessions(
 		}
 		return validated;
 	} catch (error) {
-		logger.error("Failed to list local claude code sessions:", error);
+		logger.error("Failed to list local or cloud claude code sessions:", error);
 		throw error;
 	}
 }

--- a/src/lib/components/buss/local-agent-panel/cloud-runing-card.svelte
+++ b/src/lib/components/buss/local-agent-panel/cloud-runing-card.svelte
@@ -8,13 +8,14 @@
 
 	import StatusIndicator from "$lib/components/buss/local-agent-panel/status-indicator.svelte";
 
-	import { Button } from "$lib/components/ui/button";
 	import * as AlertDialog from "$lib/components/ui/alert-dialog";
+	import { Button } from "$lib/components/ui/button";
 	import { Label } from "$lib/components/ui/label";
 	import { Skeleton } from "$lib/components/ui/skeleton";
 	import { m } from "$lib/paraglide/messages";
 	import { cloudModeState } from "$lib/stores/code-agent/cloud-mode-state.svelte";
 	import { RefreshCw } from "@lucide/svelte";
+	import { toast } from "svelte-sonner";
 	import { cn } from "tailwind-variants";
 	import { ButtonWithTooltip } from "../button-with-tooltip";
 
@@ -26,9 +27,13 @@
 		confirmDialogOpen = true;
 	}
 
-	function handleRestartConfirm() {
-		confirmDialogOpen = false;
-		cloudModeState.restartMachine();
+	async function handleRestartConfirm() {
+		try {
+			await cloudModeState.restartMachine();
+			confirmDialogOpen = false;
+		} catch (e) {
+			toast.error(m.cloud_mode_instance_restart_failed() + e);
+		}
 	}
 
 	function resolveOpenClawStatus(v: boolean | null): "green" | "red" | "gray" {

--- a/src/lib/components/buss/local-agent-panel/cloud-runing-card.svelte
+++ b/src/lib/components/buss/local-agent-panel/cloud-runing-card.svelte
@@ -9,6 +9,7 @@
 	import StatusIndicator from "$lib/components/buss/local-agent-panel/status-indicator.svelte";
 
 	import { Button } from "$lib/components/ui/button";
+	import * as AlertDialog from "$lib/components/ui/alert-dialog";
 	import { Label } from "$lib/components/ui/label";
 	import { Skeleton } from "$lib/components/ui/skeleton";
 	import { m } from "$lib/paraglide/messages";
@@ -17,7 +18,18 @@
 	import { cn } from "tailwind-variants";
 	import { ButtonWithTooltip } from "../button-with-tooltip";
 
-	let { state, openClaw, loading, healthProps } = $derived(cloudModeState.init());
+	let { state: _state, openClaw, loading, healthProps } = $derived(cloudModeState.init());
+
+	let confirmDialogOpen = $state(false);
+
+	function handleRestartClick() {
+		confirmDialogOpen = true;
+	}
+
+	function handleRestartConfirm() {
+		confirmDialogOpen = false;
+		cloudModeState.restartMachine();
+	}
 
 	function resolveOpenClawStatus(v: boolean | null): "green" | "red" | "gray" {
 		return v == null ? "gray" : v ? "green" : "red";
@@ -69,7 +81,7 @@
 					warningTooltip={m.cloud_mode_unhealthy()}
 				/>
 				<ButtonWithTooltip
-					onclick={() => cloudModeState.restartMachine()}
+					onclick={handleRestartClick}
 					tooltip={m.cloud_mode_reboot_instance()}
 					class="hover:!bg-icon-btn-hover size-8"
 				>
@@ -95,14 +107,31 @@
 				/>
 			</div>
 		</div>
-		{#if state.instanceName === ""}
+		{#if _state.instanceName === ""}
 			<Button size="sm" onclick={handleActivate}>
 				{m.cloud_mode_activate_button()}
 			</Button>
-		{:else if state.expired}
+		{:else if _state.expired}
 			<Button size="sm" onclick={handleActivate}>
 				{m.cloud_mode_renew_button()}
 			</Button>
 		{/if}
 	</div>
 {/if}
+
+<AlertDialog.Root bind:open={confirmDialogOpen}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>{m.cloud_mode_restart_machine_confirm_title()}</AlertDialog.Title>
+			<AlertDialog.Description>
+				{m.cloud_mode_restart_machine_confirm_desc()}
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel>{m.common_cancel()}</AlertDialog.Cancel>
+			<AlertDialog.Action onclick={handleRestartConfirm}>
+				{m.cloud_mode_confirm()}
+			</AlertDialog.Action>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>

--- a/src/lib/stores/code-agent/cloud-mode-sessions-state.svelte.ts
+++ b/src/lib/stores/code-agent/cloud-mode-sessions-state.svelte.ts
@@ -1,4 +1,4 @@
-import { deleteLocalSession, listLocalSessions } from "$lib/api/sandbox-session";
+import { deleteLocalOrCloudSession, listLocalOrCloudSessions } from "$lib/api/sandbox-session";
 import type { GroupedSelectData } from "$lib/components/buss/settings/setting-select.svelte";
 import { PersistedState } from "$lib/hooks/persisted-state.svelte";
 import { m } from "$lib/paraglide/messages";
@@ -201,7 +201,7 @@ class CloudModeSessionsState {
 	async refreshSessions(): Promise<void> {
 		this.isLoading = true;
 		try {
-			const response = await listLocalSessions("cloud");
+			const response = await listLocalOrCloudSessions("cloud");
 			if (response.success) {
 				persistedCloudModeSessionsState.current = response.session_list;
 			} else {
@@ -253,7 +253,7 @@ class CloudModeSessionsState {
 	 * Delete a local session
 	 */
 	async deleteSession(sessionId: string): Promise<boolean> {
-		const result = await deleteLocalSession(sessionId, "cloud");
+		const result = await deleteLocalOrCloudSession(sessionId, "cloud");
 
 		if (result.success) {
 			await this.refreshSessions();

--- a/src/lib/stores/code-agent/cloud-mode-state.svelte.ts
+++ b/src/lib/stores/code-agent/cloud-mode-state.svelte.ts
@@ -54,6 +54,8 @@ class CloudModeStateManager {
 		api_status: null as boolean | null,
 	});
 
+	#bufferTimeout: ReturnType<typeof setTimeout> | null = $state(null);
+
 	healthProps = $derived.by(() => {
 		const { status } = this.state;
 		switch (status) {
@@ -95,6 +97,12 @@ class CloudModeStateManager {
 	constructor() {
 		window.electronAPI.cloudMode.onTimedBroadcaster((healthData) => {
 			if (healthData) {
+				if (this.#bufferTimeout !== null && healthData.oc_status !== "ok") {
+					logger.debug(
+						"[CloudModeStateManager] Skipping health update during buffer period",
+					);
+					return;
+				}
 				this.openClaw.status = healthData.oc_status === "ok";
 				this.openClaw.api_status = healthData.status === "ok";
 				logger.debug("Cloud instance health updated from broadcast", {
@@ -110,15 +118,24 @@ class CloudModeStateManager {
 	 */
 	private async afterInstanceOperation(): Promise<void> {
 		try {
-			// 1. Sync instance info and start polling
+			// 1. Set 30s buffer period to allow OpenClaw to start
+			this.#bufferTimeout = setTimeout(() => {
+				this.#bufferTimeout = null;
+			}, 30000);
+
+			// 2. Sync instance info and start polling
 			const res = await window.electronAPI.cloudModeService.syncAndStartPollingByIpc();
 			if (!res.isOk) {
 				logger.warn("[CloudModeStateManager] Sync after operation failed");
 			}
 
-			// 2. Immediately refresh health status (don't wait for 30s polling)
+			// 3. Immediately refresh health status (don't wait for 30s polling)
 			await window.electronAPI.cloudModeService.refreshHealthByIpc();
 		} catch (e) {
+			if (this.#bufferTimeout) {
+				clearTimeout(this.#bufferTimeout);
+				this.#bufferTimeout = null;
+			}
 			logger.error("[CloudModeStateManager] afterInstanceOperation failed:", e);
 		}
 	}

--- a/src/lib/stores/code-agent/cloud-mode-state.svelte.ts
+++ b/src/lib/stores/code-agent/cloud-mode-state.svelte.ts
@@ -1,17 +1,16 @@
 import {
 	createInstance,
-	initInstance,
 	manualRenew,
+	readInstanceFiles,
 	rebootInstance,
 	restartDocker,
 	updateInstanceAutoRenew,
 } from "$lib/api/cloud-mode/base-apis";
-import { _302AIKy } from "$lib/api/core/_302ai-ky";
 import { PersistedState } from "$lib/hooks/persisted-state.svelte";
 import { m } from "$lib/paraglide/messages";
 import { createLogger } from "@shared/logger";
-import { CloudModeApiError } from "@shared/storage/cloud-mode-errors";
 import type { InstanceInfo } from "@shared/storage/cloud-mode";
+import { CloudModeApiError } from "@shared/storage/cloud-mode-errors";
 import { onMount } from "svelte";
 import { toast } from "svelte-sonner";
 
@@ -202,6 +201,21 @@ class CloudModeStateManager {
 		}
 	}
 
+	/**
+	 * Unified Cloud Mode error handler: resolves i18n message, shows toast, and re-throws.
+	 * Returns `never` so TypeScript knows the catch block always throws.
+	 */
+	#handleError(error: unknown): never {
+		if (error instanceof CloudModeApiError) {
+			const i18nKey = error.getI18nKey();
+			const messageFunc = (m as unknown as Record<string, () => string>)[i18nKey];
+			toast.error(messageFunc ? messageFunc() : m.cloud_mode_error_unknown());
+		} else {
+			toast.error(m.cloud_mode_error_unknown());
+		}
+		throw error;
+	}
+
 	async loadInstances() {
 		try {
 			const res = await window.electronAPI.cloudModeService.syncCloudInstanceToLocalByIpc();
@@ -209,15 +223,7 @@ class CloudModeStateManager {
 				throw new Error("Failed to load cloud instance status");
 			}
 		} catch (error) {
-			if (error instanceof CloudModeApiError) {
-				const i18nKey = error.getI18nKey();
-				const messageFunc = (m as unknown as Record<string, () => string>)[i18nKey];
-				const message = messageFunc ? messageFunc() : m.cloud_mode_error_unknown();
-				toast.error(message);
-			} else {
-				toast.error(m.cloud_mode_error_unknown());
-			}
-			throw error;
+			this.#handleError(error);
 		}
 	}
 
@@ -234,15 +240,7 @@ class CloudModeStateManager {
 				// Unified handler: sync + start polling
 				await this.afterInstanceOperation();
 			} catch (error) {
-				if (error instanceof CloudModeApiError) {
-					const i18nKey = error.getI18nKey();
-					const messageFunc = (m as unknown as Record<string, () => string>)[i18nKey];
-					const message = messageFunc ? messageFunc() : m.cloud_mode_error_unknown();
-					toast.error(message);
-				} else {
-					toast.error(m.cloud_mode_error_unknown());
-				}
-				throw error;
+				this.#handleError(error);
 			}
 		})();
 	}
@@ -260,15 +258,7 @@ class CloudModeStateManager {
 				// Unified handler: sync + start polling
 				await this.afterInstanceOperation();
 			} catch (error) {
-				if (error instanceof CloudModeApiError) {
-					const i18nKey = error.getI18nKey();
-					const messageFunc = (m as unknown as Record<string, () => string>)[i18nKey];
-					const message = messageFunc ? messageFunc() : m.cloud_mode_error_unknown();
-					toast.error(message);
-				} else {
-					toast.error(m.cloud_mode_error_unknown());
-				}
-				throw error;
+				this.#handleError(error);
 			}
 		})();
 	}
@@ -288,15 +278,7 @@ class CloudModeStateManager {
 				logger.info("Auto-renew setting updated successfully");
 			} catch (error) {
 				this.#updateState({ autoRenew: originalAutoRenew });
-				if (error instanceof CloudModeApiError) {
-					const i18nKey = error.getI18nKey();
-					const messageFunc = (m as unknown as Record<string, () => string>)[i18nKey];
-					const message = messageFunc ? messageFunc() : m.cloud_mode_error_unknown();
-					toast.error(message);
-				} else {
-					toast.error(m.cloud_mode_error_unknown());
-				}
-				throw error;
+				this.#handleError(error);
 			}
 		})();
 	}
@@ -306,16 +288,14 @@ class CloudModeStateManager {
 		if (!publicIp || !ocPort || !instanceName) return null;
 
 		try {
-			const response = (await _302AIKy
-				.post("302/swas/instances/files/read", {
-					json: {
-						instance_name: instanceName,
-						file_paths: ["/home/user/.openclaw/openclaw.json"],
-					},
-				})
-				.json()) as { files: Array<{ file_content: string }> };
+			const response = await readInstanceFiles({
+				instanceName,
+				filePaths: ["/home/user/.openclaw/openclaw.json"],
+			});
 
-			const fileContent = response.files[0].file_content;
+			const fileContent = response.files[0]?.fileContent;
+			if (!fileContent) return null;
+
 			const config = JSON.parse(fileContent) as {
 				gateway?: { auth?: { token?: string } };
 			};
@@ -350,10 +330,10 @@ class CloudModeStateManager {
 						throw new Error("Failed to create instance");
 					}
 
-					await initInstance({
-						instanceName: res.instance.instanceName,
-						isDev: true, // TODO: remove this when ready
-					});
+					// await initInstance({
+					// 	instanceName: res.instance.instanceName,
+					// 	isDev: true, // TODO: remove this when ready
+					// });
 
 					logger.info("Instance created successfully");
 				}
@@ -361,15 +341,7 @@ class CloudModeStateManager {
 				// Unified handler: sync + start polling
 				await this.afterInstanceOperation();
 			} catch (error) {
-				if (error instanceof CloudModeApiError) {
-					const i18nKey = error.getI18nKey();
-					const messageFunc = (m as unknown as Record<string, () => string>)[i18nKey];
-					const message = messageFunc ? messageFunc() : m.cloud_mode_error_unknown();
-					toast.error(message);
-				} else {
-					toast.error(m.cloud_mode_error_unknown());
-				}
-				throw error;
+				this.#handleError(error);
 			}
 		})();
 	}

--- a/src/lib/stores/code-agent/local-claude-code-sandbox-state.svelte.ts
+++ b/src/lib/stores/code-agent/local-claude-code-sandbox-state.svelte.ts
@@ -1,4 +1,4 @@
-import { deleteLocalSession, listLocalSessions } from "$lib/api/sandbox-session";
+import { deleteLocalOrCloudSession, listLocalOrCloudSessions } from "$lib/api/sandbox-session";
 import type { GroupedSelectData } from "$lib/components/buss/settings/setting-select.svelte";
 import { PersistedState } from "$lib/hooks/persisted-state.svelte";
 import { m } from "$lib/paraglide/messages";
@@ -201,7 +201,7 @@ class LocalClaudeCodeSandboxState {
 	async refreshSessions(): Promise<void> {
 		this.isLoading = true;
 		try {
-			const response = await listLocalSessions("local");
+			const response = await listLocalOrCloudSessions("local");
 			if (response.success) {
 				persistedLocalClaudeCodeSessionsState.current = response.session_list;
 			}
@@ -254,7 +254,7 @@ class LocalClaudeCodeSandboxState {
 		const session = this.sessions.find((s) => s.session_id === sessionId);
 		const workspacePath = session?.workspace_path;
 
-		const result = await deleteLocalSession(sessionId, "local");
+		const result = await deleteLocalOrCloudSession(sessionId, "local");
 
 		if (result.success) {
 			// Delete the local workspace directory if it exists.

--- a/src/routes/(settings-page)/settings/(full-width)/agent-settings/cloud-platform.svelte
+++ b/src/routes/(settings-page)/settings/(full-width)/agent-settings/cloud-platform.svelte
@@ -142,6 +142,7 @@
 	async function handleRestartOpenClaw() {
 		try {
 			await cloudModeState.restartOpenClaw();
+			showRestartOpenClawDialog = false;
 		} catch (e) {
 			toast.error(m.cloud_mode_openclaw_restart_failed() + e);
 		}
@@ -150,6 +151,7 @@
 	async function handleRestartMachine() {
 		try {
 			await cloudModeState.restartMachine();
+			showRestartMachineDialog = false;
 		} catch (e) {
 			toast.error(m.cloud_mode_instance_restart_failed() + e);
 		}

--- a/src/routes/(settings-page)/settings/(full-width)/agent-settings/cloud-platform.svelte
+++ b/src/routes/(settings-page)/settings/(full-width)/agent-settings/cloud-platform.svelte
@@ -142,6 +142,7 @@
 	async function handleRestartOpenClaw() {
 		try {
 			await cloudModeState.restartOpenClaw();
+			showRestartOpenClawDialog = false;
 		} catch (e) {
 			toast.error(m.cloud_mode_openclaw_restart_failed() + e);
 		}
@@ -150,6 +151,7 @@
 	async function handleRestartMachine() {
 		try {
 			await cloudModeState.restartMachine();
+			showRestartMachineDialog = false;
 		} catch (e) {
 			toast.error(m.cloud_mode_instance_restart_failed() + e);
 		}
@@ -218,7 +220,7 @@
 								warningTooltip={m.cloud_mode_unhealthy()}
 							/>
 							<div class="relative size-5">
-								{#if !cloudState.expired && cloudState.instanceName}
+								{#if !cloudState.expired && cloudState.instanceName && cloudState.status == "running"}
 									<ButtonWithTooltip
 										onclick={() => (showRestartMachineDialog = true)}
 										tooltip={m.cloud_mode_reboot_instance()}

--- a/src/routes/(settings-page)/settings/(full-width)/agent-settings/cloud-platform.svelte
+++ b/src/routes/(settings-page)/settings/(full-width)/agent-settings/cloud-platform.svelte
@@ -208,7 +208,7 @@
 			<div class="rounded-lg border p-5 space-y-5">
 				<div class="flex items-start justify-between gap-4">
 					<div class="flex-1 space-y-3">
-						<div class="flex items-center gap-3">
+						<div class="flex items-center gap-2 mb-2!">
 							<Label class="text-muted-foreground min-w-18 font-normal"
 								>{m.agent_settings_instance_status()}</Label
 							>
@@ -231,7 +231,7 @@
 								{/if}
 							</div>
 						</div>
-						<div class="flex items-center gap-3">
+						<div class="flex items-center gap-2 mb-2!">
 							<Label class="text-muted-foreground min-w-18 font-normal"
 								>{m.cloud_mode_openclaw_status()}</Label
 							>
@@ -257,7 +257,7 @@
 								{/if}
 							</div>
 						</div>
-						<div class="flex items-center gap-3">
+						<div class="flex items-center gap-2 mb-2!">
 							<Label class="text-muted-foreground min-w-18 font-normal"
 								>{m.cloud_mode_api_status()}</Label
 							>

--- a/src/routes/(settings-page)/settings/(full-width)/agent-settings/cloud-platform.svelte
+++ b/src/routes/(settings-page)/settings/(full-width)/agent-settings/cloud-platform.svelte
@@ -218,7 +218,7 @@
 								warningTooltip={m.cloud_mode_unhealthy()}
 							/>
 							<div class="relative size-5">
-								{#if !cloudState.expired}
+								{#if !cloudState.expired && cloudState.instanceName}
 									<ButtonWithTooltip
 										onclick={() => (showRestartMachineDialog = true)}
 										tooltip={m.cloud_mode_reboot_instance()}


### PR DESCRIPTION
## Changes
- Updated `src/routes/(settings-page)/settings/(full-width)/agent-settings/cloud-platform.svelte` to automatically close confirmation dialogs after triggering a restart.

## Description
When clicking the confirm button for 'Restart Instance' or 'Restart OpenClaw', the dialog remained open, which was misleading to users. This PR ensures the dialogs are dismissed upon the corresponding action's success.