### PR TITLE
fix(cloud-mode): optimize polling, openclaw restart, and dmg build

### DIFF
--- a/electron/main/services/cloud-mode-sevice/index.ts
+++ b/electron/main/services/cloud-mode-sevice/index.ts
@@ -8,7 +8,7 @@ import type { InstanceInfo, SandboxHealthResponse } from "@shared/storage/cloud-
 import type { IpcMainInvokeEvent } from "electron";
 import { attemptAsync, isNull } from "es-toolkit";
 import { broadcastService } from "../broadcast-service";
-import { schedulerService } from "../scheduler-service";
+import { CRON_EXPRESSION, schedulerService } from "../scheduler-service";
 
 const logger = createLogger("services");
 
@@ -50,7 +50,8 @@ export class CloudModeService {
 	 */
 	private startPolling(mode: "fast" | "normal" = "normal"): void {
 		// Sync instance info: 20s if fast, 5m if normal
-		const instanceSyncCron = mode === "fast" ? "*/20 * * * * *" : "0 */5 * * * *";
+		const instanceSyncCron =
+			mode === "fast" ? CRON_EXPRESSION.EVERY_20_SECONDS : CRON_EXPRESSION.EVERY_5_MINUTES;
 
 		schedulerService.addTask("cloud-mode-instance-sync", instanceSyncCron, async () => {
 			const [error, instances] = await attemptAsync(() => this.syncCloudInstanceToLocal());
@@ -69,10 +70,14 @@ export class CloudModeService {
 			await this.checkAndStopPolling();
 		});
 
-		// Health check every 30 seconds
-		schedulerService.addTask("cloud-mode-health-polling", "*/30 * * * * *", async () => {
-			await this.fetchAndBroadcastHealth();
-		});
+		// Health check every 15 seconds
+		schedulerService.addTask(
+			"cloud-mode-health-polling",
+			CRON_EXPRESSION.EVERY_15_SECONDS,
+			async () => {
+				await this.fetchAndBroadcastHealth();
+			},
+		);
 	}
 
 	/**

--- a/electron/main/services/scheduler-service/index.ts
+++ b/electron/main/services/scheduler-service/index.ts
@@ -13,6 +13,14 @@ export const CRON_EXPRESSION = {
 	 */
 	EVERY_10_SECONDS: "*/10 * * * * *",
 	/**
+	 * Run every 15 seconds
+	 */
+	EVERY_15_SECONDS: "*/15 * * * * *",
+	/**
+	 * Run every 20 seconds
+	 */
+	EVERY_20_SECONDS: "*/20 * * * * *",
+	/**
 	 * Run every 30 seconds
 	 */
 	EVERY_30_SECONDS: "*/30 * * * * *",

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -142,10 +142,13 @@ const config: ForgeConfig = {
 			["win32"],
 		),
 		new MakerZIP({}, ["darwin", "win32"]),
-		new MakerDMG({
-			icon: "static/icon.icns",
-			format: "ULFO",
-		}),
+		new MakerDMG(
+			{
+				icon: "static/icon.icns",
+				format: "ULFO",
+			},
+			["darwin"],
+		),
 		new MakerRpm({
 			options: {
 				icon: "static/icon.png",

--- a/src/lib/stores/code-agent/openclaw/openclaw-config-state.svelte.ts
+++ b/src/lib/stores/code-agent/openclaw/openclaw-config-state.svelte.ts
@@ -161,16 +161,16 @@ class OpenClawConfigState {
 	}
 
 	async bindingAndRestartCloud(ocAgentId: string) {
-		await this.updateOCBindingsCloud(ocAgentId);
-
 		if (!this.hasConfigs) return;
+
+		await this.updateOCBindingsCloud(ocAgentId);
 
 		const instanceName = cloudModeState.state.instanceName;
 		if (!instanceName) {
 			throw new Error("Cloud instance not found");
 		}
 
-		await window.electronAPI.openClawService.restartCloudOpenClaw(instanceName);
+		// await window.electronAPI.openClawService.restartCloudOpenClaw(instanceName);
 
 		let cleanup: (() => void) | undefined;
 


### PR DESCRIPTION
## 📝 Summary

Optimize cloud mode instance synchronization, adjust OpenClaw restart behavior, and fix potential build issues on non-macOS platforms.

## 🚀 Key Features / Changes

### 🛠 Refactoring / Fixes

- **Cloud Mode**: Refactored the scheduler service to use centralized `CRON_EXPRESSION` constants. Reduced the cloud mode health polling interval from 30 seconds to 15 seconds for faster state synchronization.
- **OpenClaw**: Reordered the `hasConfigs` validation to execute before cloud mode binding to ensure proper configuration exists. Temporarily disabled the `restartCloudOpenClaw` API call to prevent premature instance restarts.
- **Build**: Restricted `MakerDMG` generation to the `["darwin"]` platform in `forge.config.ts` to prevent potential build errors on non-macOS systems.

## 🔍 Description

This PR addresses several minor optimizations and fixes:
1. Improves the responsiveness of cloud mode health checks.
2. Centralizes cron expressions for better maintainability.
3. Prevents an issue where OpenClaw instances might restart unnecessarily.
4. Ensures Electron Forge macOS-specific builds (DMG) only run on macOS.

## 🧪 Test Plan

- [x] **Quality Gates**: Ran `pnpm quality` (lint, format, type-check) and passed (verified via pre-commit hooks)
- [ ] **Manual Testing**:
    - [ ] Verify cloud mode health polling interval.
    - [ ] Verify OpenClaw bindings update without restarting the cloud instance.
- [ ] **Regressions**: Confirmed no breaking changes or regressions