### PR TITLE
chore(skills): update commit-and-pr skill to prevent direct commits to target branch

### DIFF
--- a/.agents/skills/commit-and-pr/SKILL.md
+++ b/.agents/skills/commit-and-pr/SKILL.md
@@ -19,9 +19,10 @@ Follow these steps exactly in order:
    - Ask the user: "What should the target base branch be for this PR? (And optionally, what do you want to name the new branch?)"
    - **WAIT** for the user's response. Do not proceed to step 2 until they answer.
 
-2. **Checkout Branch**:
+2. **Checkout Branch (CRITICAL)**:
    - If the user did not provide a branch name, generate one based on the changes using conventional prefixes (e.g., `feat/xxx`, `fix/xxx`, `chore/xxx`).
-   - Run `git checkout -b <branch-name>`.
+   - **CRITICAL RULE:** If the current branch is the same as the target base branch the user specified, you MUST checkout a new branch (e.g., `git checkout -b <new-branch-name>`). You must NEVER commit and push directly to the target base branch.
+   - Run `git checkout -b <branch-name>` (or `git checkout <branch-name>` if the user provided an existing one and it's not the base branch).
 
 3. **Commit Code**:
    - Write a conventional commit message describing the changes.

--- a/.claude/skills/commit-and-pr/SKILL.md
+++ b/.claude/skills/commit-and-pr/SKILL.md
@@ -19,9 +19,10 @@ Follow these steps exactly in order:
    - Ask the user: "What should the target base branch be for this PR? (And optionally, what do you want to name the new branch?)"
    - **WAIT** for the user's response. Do not proceed to step 2 until they answer.
 
-2. **Checkout Branch**:
+2. **Checkout Branch (CRITICAL)**:
    - If the user did not provide a branch name, generate one based on the changes using conventional prefixes (e.g., `feat/xxx`, `fix/xxx`, `chore/xxx`).
-   - Run `git checkout -b <branch-name>`.
+   - **CRITICAL RULE:** If the current branch is the same as the target base branch the user specified, you MUST checkout a new branch (e.g., `git checkout -b <new-branch-name>`). You must NEVER commit and push directly to the target base branch.
+   - Run `git checkout -b <branch-name>` (or `git checkout <branch-name>` if the user provided an existing one and it's not the base branch).
 
 3. **Commit Code**:
    - Write a conventional commit message describing the changes.

--- a/.claude/skills/commit-and-pr/eval_set.json
+++ b/.claude/skills/commit-and-pr/eval_set.json
@@ -1,0 +1,66 @@
+[
+    {
+        "query": "commit these changes and make a PR to dev/26.16",
+        "should_trigger": true
+    },
+    {
+        "query": "push my current branch and open a pull request",
+        "should_trigger": true
+    },
+    {
+        "query": "i'm done with the settings page refactor, can you commit and PR this?",
+        "should_trigger": true
+    },
+    {
+        "query": "create a PR for the stuff I just worked on",
+        "should_trigger": true
+    },
+    {
+        "query": "I finished the changes in claude-code-state.svelte.ts, please commit it and make a pull request against master",
+        "should_trigger": true
+    },
+    {
+        "query": "wrap this up, commit, push, and PR",
+        "should_trigger": true
+    },
+    {
+        "query": "hey, my boss wants this hotfix up ASAP, push it and PR to main",
+        "should_trigger": true
+    },
+    {
+        "query": "ok i think the auth feature is done. push the code and open a PR",
+        "should_trigger": true
+    },
+    {
+        "query": "how do I use git rebase to squash my commits?",
+        "should_trigger": true
+    },
+    {
+        "query": "can you review my pull request #55?",
+        "should_trigger": false
+    },
+    {
+        "query": "what's the git command to create a new branch?",
+        "should_trigger": false
+    },
+    {
+        "query": "help me resolve this merge conflict in page.svelte",
+        "should_trigger": false
+    },
+    {
+        "query": "write a PR description for the changes I made to the database schema",
+        "should_trigger": false
+    },
+    {
+        "query": "why is my GitHub Actions PR workflow failing?",
+        "should_trigger": false
+    },
+    {
+        "query": "can you check the diff of my current changes and tell me if I broke anything?",
+        "should_trigger": false
+    },
+    {
+        "query": "create a new issue for the bug in the settings page",
+        "should_trigger": false
+    }
+]


### PR DESCRIPTION
## 📝 Summary

Update the `commit-and-pr` skill to enforce safer git workflows and add an evaluation set.

## 🚀 Key Features / Changes

### 🧹 Chore / Others

- **Skill Update**: Modified `commit-and-pr` skill (`SKILL.md`) to explicitly forbid direct commits to the target base branch. If the user is currently on the target base branch, the agent is now forced to checkout a new branch first. This prevents accidentally pushing changes directly to protected or active integration branches.
- **Eval Set**: Added an evaluation set (`eval_set.json`) for the `commit-and-pr` skill to improve trigger accuracy and testing.

## 🔍 Description

This PR improves the safety of our automated git workflows. By strictly forbidding the `commit-and-pr` skill from committing directly to the target base branch (e.g. `dev/26.16`), we prevent accidental direct pushes and ensure that changes are always isolated in feature/fix branches before a PR is opened.

## 🧪 Test Plan

- [x] **Quality Gates**: Ran `pnpm quality` (lint, format, type-check) and passed (verified via pre-commit hooks)
- [ ] **Manual Testing**:
    - [x] Verify that when on `dev/26.16`, asking the agent to "commit and PR to dev/26.16" successfully forces the creation of a new branch.
- [ ] **Regressions**: Confirmed no breaking changes or regressions