### PR TITLE
fix(page-header): replace accent colors with icon-btn-* variants for search buttons

### DIFF
--- a/src/routes/(with-sidebar)/components/page-header.svelte
+++ b/src/routes/(with-sidebar)/components/page-header.svelte
@@ -357,35 +357,13 @@
 			</ButtonWithTooltip>
 		{/if}
 
-		<!-- Skills management button (always visible) -->
-		<!-- <ButtonWithTooltip
-			class={cn(
-				"hover:!bg-icon-btn-hover",
-				agentPreviewState.isVisible &&
-					agentPreviewState.isSkillsOnlyMode &&
-					"!bg-icon-btn-active hover:!bg-icon-btn-active",
-			)}
-			tooltipSide="bottom"
-			tooltip={m.title_skills_management()}
-			onclick={handleSkillsOnlyToggle}
-		>
-			<BookOpen
-				class={cn(
-					"size-5",
-					agentPreviewState.isVisible &&
-						agentPreviewState.isSkillsOnlyMode &&
-						"!text-icon-btn-active-fg",
-				)}
-			/>
-		</ButtonWithTooltip> -->
-
 		<div class="relative">
 			{#if chatState.hasMessages}
 				<ButtonWithTooltip
 					class={cn(
-						"hover:!bg-accent hover:!text-accent-foreground",
+						"hover:!bg-icon-btn-hover",
 						chatState.isSearchInput &&
-							"!bg-accent !text-accent-foreground hover:!bg-accent hover:!text-accent-foreground",
+							"!bg-icon-btn-active !text-icon-btn-active-fg hover:!bg-icon-btn-active hover:!text-icon-btn-active-fg",
 					)}
 					tooltipSide="bottom"
 					tooltip={m.tooltip_search_content()}
@@ -415,8 +393,8 @@
 							class={cn(
 								"flex size-5 cursor-pointer items-center justify-center rounded transition-colors",
 								caseSensitive
-									? "bg-accent text-accent-foreground"
-									: "text-foreground/70 hover:bg-accent hover:text-accent-foreground",
+									? "bg-icon-btn-active text-icon-btn-active-fg"
+									: "text-foreground/70 hover:bg-icon-btn-hover",
 							)}
 							title={m.search_case_sensitive()}
 							onclick={toggleCaseSensitive}
@@ -427,8 +405,8 @@
 							class={cn(
 								"flex size-5 cursor-pointer items-center justify-center rounded transition-colors",
 								wholeWord
-									? "bg-accent text-accent-foreground"
-									: "text-foreground/70 hover:bg-accent hover:text-accent-foreground",
+									? "bg-icon-btn-active text-icon-btn-active-fg"
+									: "text-foreground/70 hover:bg-icon-btn-hover",
 							)}
 							title={m.search_whole_word()}
 							onclick={toggleWholeWord}
@@ -439,8 +417,8 @@
 							class={cn(
 								"flex size-5 cursor-pointer items-center justify-center rounded transition-colors",
 								useRegex
-									? "bg-accent text-accent-foreground"
-									: "text-foreground/70 hover:bg-accent hover:text-accent-foreground",
+									? "bg-icon-btn-active text-icon-btn-active-fg"
+									: "text-foreground/70 hover:bg-icon-btn-hover",
 							)}
 							title={m.search_regex()}
 							onclick={toggleRegex}
@@ -460,14 +438,14 @@
 								{/if}
 							</span>
 							<button
-								class="cursor-pointer text-foreground/70 hover:bg-accent hover:text-accent-foreground flex items-center justify-center rounded p-0.5 transition-colors disabled:opacity-50"
+								class="cursor-pointer text-foreground/70 hover:bg-icon-btn-hover hover:text-foreground flex items-center justify-center rounded p-0.5 transition-colors disabled:opacity-50"
 								onclick={handlePrevMatch}
 								disabled={totalMatches === 0}
 							>
 								<ChevronUp class="size-3.5" />
 							</button>
 							<button
-								class="cursor-pointer text-foreground/70 hover:bg-accent hover:text-accent-foreground flex items-center justify-center rounded p-0.5 transition-colors disabled:opacity-50"
+								class="cursor-pointer text-foreground/70 hover:bg-icon-btn-hover hover:text-foreground flex items-center justify-center rounded p-0.5 transition-colors disabled:opacity-50"
 								onclick={handleNextMatch}
 								disabled={totalMatches === 0}
 							>


### PR DESCRIPTION
## 📝 Summary

Replace hardcoded accent color styles with semantic icon-button CSS variants for search-related toggle buttons in the page header component.

## 🚀 Key Features / Changes

### 🛠 Refactoring / Fixes

- Update case sensitive, whole word, and regex toggle buttons to use `icon-btn-active`/`icon-btn-hover` styles
- Update prev/next match navigation buttons with consistent icon button styling
- Remove commented-out skills management button code

## 🔍 Description

The search buttons in the page header were using `bg-accent`/`hover:bg-accent` directly. This change standardizes them to use the project's icon button semantic CSS classes (`icon-btn-active`, `icon-btn-hover`, `icon-btn-active-fg`) for better consistency with other UI elements.

## 🧪 Test Plan

- [ ] **Quality Gates**: Ran `pnpm quality` (lint, format, type-check) and passed
- [ ] **Manual Testing**:
    - [ ] Verified search toggle buttons (case sensitive, whole word, regex) display correctly
    - [ ] Verified prev/next match navigation buttons work correctly
- [ ] **Regressions**: Confirmed no breaking changes or regressions

## 📂 Files Changed

- `src/routes/(with-sidebar)/components/page-header.svelte`: Search button styling updates