### PR TITLE
fix(about): reset export logs date to today when cleared

### DIFF
--- a/src/routes/(settings-page)/settings/(center)/about/+page.svelte
+++ b/src/routes/(settings-page)/settings/(center)/about/+page.svelte
@@ -19,6 +19,7 @@
 	import { CalendarDate, type DateValue } from "@internationalized/date";
 	import { Calendar as CalendarIcon, LoaderCircle } from "@lucide/svelte";
 	import { createLogger } from "@shared/logger";
+	import { isUndefined } from "es-toolkit";
 	import { onMount } from "svelte";
 	import { toast } from "svelte-sonner";
 
@@ -38,10 +39,12 @@
 	let openExportDialog = $state(false);
 	let isExporting = $state(false);
 
-	const now = new Date();
-	let selectedDate = $state<DateValue>(
-		new CalendarDate(now.getFullYear(), now.getMonth() + 1, now.getDate()),
+	const today = new CalendarDate(
+		new Date().getFullYear(),
+		new Date().getMonth() + 1,
+		new Date().getDate(),
 	);
+	let selectedDate = $state<DateValue | undefined>(today);
 	let startHour = $state("0");
 	let endHour = $state("24");
 
@@ -59,17 +62,19 @@
 
 	const calendarLocale = $derived(getLocale() === "zh" ? "zh-CN" : "en-US");
 
+	// Reset to today when date is cleared (e.g., user cancels selection)
+	$effect(() => {
+		if (isUndefined(selectedDate)) {
+			selectedDate = today;
+		}
+	});
+
 	// Calendar date range: last 14 days
-	const minDate = $derived(
-		new CalendarDate(now.getFullYear(), now.getMonth() + 1, now.getDate()).subtract({
-			days: 13,
-		}),
-	);
-	const maxDate = $derived(
-		new CalendarDate(now.getFullYear(), now.getMonth() + 1, now.getDate()),
-	);
+	const minDate = $derived(today.subtract({ days: 13 }));
+	const maxDate = $derived(today);
 
 	async function handleExportLogs() {
+		if (isUndefined(selectedDate)) return;
 		try {
 			isExporting = true;
 			const dateStr = `${selectedDate.year}-${String(selectedDate.month).padStart(2, "0")}-${String(selectedDate.day).padStart(2, "0")}`;
@@ -240,10 +245,9 @@
 							class="w-full justify-start text-left font-normal"
 						>
 							<CalendarIcon class="mr-2 h-4 w-4" />
-							{selectedDate.year}-{String(selectedDate.month).padStart(
-								2,
-								"0",
-							)}-{String(selectedDate.day).padStart(2, "0")}
+							{!isUndefined(selectedDate)
+								? `${selectedDate.year}-${String(selectedDate.month).padStart(2, "0")}-${String(selectedDate.day).padStart(2, "0")}`
+								: m.about_export_logs_date()}
 						</Button>
 					</Popover.Trigger>
 					<Popover.Content class="w-auto p-0">


### PR DESCRIPTION
## 📝 Summary

This PR fixes an issue in the About page where the export logs date could be left in an inconsistent state if cleared. It ensures the date is automatically reset to today when it becomes undefined.

## 🚀 Key Features / Changes

### 🛠 Refactoring / Fixes

- Added an effect to reset `selectedDate` to today if it becomes undefined.
- Simplified `today` initialization using `CalendarDate`.
- Added defensive checks (`isUndefined`) before processing log exports.
- Updated the UI to handle the date display more robustly.

## 🔍 Description

When a user interacts with the date picker for exporting logs, if they somehow clear the selection, the system might crash or behave unexpectedly when attempting to export. This change ensures there is always a valid date selected by defaulting back to 'today'.

## 🧪 Test Plan

- [x] **Quality Gates**: Ran `pnpm quality` (lint, format, type-check) and passed
- [x] **Manual Testing**:
    - [x] Open About page -> Export Logs -> Clear date -> Verify it resets to today.
    - [x] Select a past date -> Export -> Verify success.
- [x] **Regressions**: Confirmed no breaking changes or regressions

## 📂 Files Changed

- `src/routes/(settings-page)/settings/(center)/about/+page.svelte`: Main logic changes for date handling.