### PR TITLE
feat(skill): add mandatory cleanup to commit-and-pr skill

### DIFF
--- a/.agents/skills/commit-and-pr/SKILL.md.bak
+++ b/.agents/skills/commit-and-pr/SKILL.md.bak
@@ -7,9 +7,6 @@ description: "Use this skill whenever the user wants to commit changes and creat
 
 This skill automates the process of committing local changes, pushing to a new branch, and opening a Pull Request using the project's PR template.
 
-## Mandatory Constraint
-**You MUST switch back to the original branch at the end of the process.** This is non-negotiable and ensures the developer's workspace remains consistent.
-
 ## Important Rule
 **NEVER proceed without asking the user for the target base branch.** Even if the user provides a prompt like "commit and PR this", you must stop and ask them for the target branch (e.g., `dev/26.16`, `master`) before doing any Git operations.
 
@@ -18,30 +15,30 @@ This skill automates the process of committing local changes, pushing to a new b
 Follow these steps exactly in order:
 
 1. **Verify State & Ask for Information**:
-   - Run \`git branch --show-current\` to save the name of the original branch.
-   - Run \`git status\` and \`git diff\` to understand the current changes.
+   - Run `git branch --show-current` to save the name of the original branch.
+   - Run `git status` and `git diff` to understand the current changes.
    - Ask the user: "What should the target base branch be for this PR? (And optionally, what do you want to name the new branch?)"
    - **WAIT** for the user's response. Do not proceed to step 2 until they answer.
 
 2. **Checkout Branch (CRITICAL)**:
-   - If the user did not provide a branch name, generate one based on the changes using conventional prefixes (e.g., \`feat/xxx\`, \`fix/xxx\`, \`chore/xxx\`).
-   - **CRITICAL RULE:** If the current branch is the same as the target base branch the user specified, you MUST checkout a new branch (e.g., \`git checkout -b <new-branch-name>\`). You must NEVER commit and push directly to the target base branch.
-   - Run \`git checkout -b <branch-name>\` (or \`git checkout <branch-name>\` if the user provided an existing one and it's not the base branch).
+   - If the user did not provide a branch name, generate one based on the changes using conventional prefixes (e.g., `feat/xxx`, `fix/xxx`, `chore/xxx`).
+   - **CRITICAL RULE:** If the current branch is the same as the target base branch the user specified, you MUST checkout a new branch (e.g., `git checkout -b <new-branch-name>`). You must NEVER commit and push directly to the target base branch.
+   - Run `git checkout -b <branch-name>` (or `git checkout <branch-name>` if the user provided an existing one and it's not the base branch).
 
 3. **Commit Code**:
    - Write a conventional commit message describing the changes.
-   - Run \`git commit -m "..."\`.
+   - Run `git commit -m "..."`.
 
 4. **Push Code**:
-   - Run \`git push -u origin <branch-name>\`.
+   - Run `git push -u origin <branch-name>`.
 
 5. **Create the PR using Specification Skill**:
-   - Once the code is pushed, you must use the \`create-github-pull-request-from-specification\` skill to create the PR.
+   - Once the code is pushed, you must use the `create-github-pull-request-from-specification` skill to create the PR.
    - Invoke the skill tool passing the target base branch the user provided:
-     \`Tool call: Skill (skill: "create-github-pull-request-from-specification", args: "--base <target-branch>")\`
+     `Tool call: Skill (skill: "create-github-pull-request-from-specification", args: "--base <target-branch>")`
 
-6. **Cleanup (MANDATORY)**:
-   - Switch back to the original branch captured in step 1: \`git checkout <original-branch>\`.
+6. **Cleanup**:
+   - Switch back to the original branch captured in step 1: `git checkout <original-branch>`.
 
 7. **Completion**:
    - Inform the user that the PR has been created and you have switched back to the original branch.

--- a/.claude/skills/commit-and-pr/SKILL.md
+++ b/.claude/skills/commit-and-pr/SKILL.md
@@ -7,6 +7,9 @@ description: "Use this skill whenever the user wants to commit changes and creat
 
 This skill automates the process of committing local changes, pushing to a new branch, and opening a Pull Request using the project's PR template.
 
+## Mandatory Constraint
+**You MUST switch back to the original branch at the end of the process.** This is non-negotiable and ensures the developer's workspace remains consistent.
+
 ## Important Rule
 **NEVER proceed without asking the user for the target base branch.** Even if the user provides a prompt like "commit and PR this", you must stop and ask them for the target branch (e.g., `dev/26.16`, `master`) before doing any Git operations.
 
@@ -15,30 +18,30 @@ This skill automates the process of committing local changes, pushing to a new b
 Follow these steps exactly in order:
 
 1. **Verify State & Ask for Information**:
-   - Run `git branch --show-current` to save the name of the original branch.
-   - Run `git status` and `git diff` to understand the current changes.
+   - Run \`git branch --show-current\` to save the name of the original branch.
+   - Run \`git status\` and \`git diff\` to understand the current changes.
    - Ask the user: "What should the target base branch be for this PR? (And optionally, what do you want to name the new branch?)"
    - **WAIT** for the user's response. Do not proceed to step 2 until they answer.
 
 2. **Checkout Branch (CRITICAL)**:
-   - If the user did not provide a branch name, generate one based on the changes using conventional prefixes (e.g., `feat/xxx`, `fix/xxx`, `chore/xxx`).
-   - **CRITICAL RULE:** If the current branch is the same as the target base branch the user specified, you MUST checkout a new branch (e.g., `git checkout -b <new-branch-name>`). You must NEVER commit and push directly to the target base branch.
-   - Run `git checkout -b <branch-name>` (or `git checkout <branch-name>` if the user provided an existing one and it's not the base branch).
+   - If the user did not provide a branch name, generate one based on the changes using conventional prefixes (e.g., \`feat/xxx\`, \`fix/xxx\`, \`chore/xxx\`).
+   - **CRITICAL RULE:** If the current branch is the same as the target base branch the user specified, you MUST checkout a new branch (e.g., \`git checkout -b <new-branch-name>\`). You must NEVER commit and push directly to the target base branch.
+   - Run \`git checkout -b <branch-name>\` (or \`git checkout <branch-name>\` if the user provided an existing one and it's not the base branch).
 
 3. **Commit Code**:
    - Write a conventional commit message describing the changes.
-   - Run `git commit -m "..."`.
+   - Run \`git commit -m "..."\`.
 
 4. **Push Code**:
-   - Run `git push -u origin <branch-name>`.
+   - Run \`git push -u origin <branch-name>\`.
 
 5. **Create the PR using Specification Skill**:
-   - Once the code is pushed, you must use the `create-github-pull-request-from-specification` skill to create the PR.
+   - Once the code is pushed, you must use the \`create-github-pull-request-from-specification\` skill to create the PR.
    - Invoke the skill tool passing the target base branch the user provided:
-     `Tool call: Skill (skill: "create-github-pull-request-from-specification", args: "--base <target-branch>")`
+     \`Tool call: Skill (skill: "create-github-pull-request-from-specification", args: "--base <target-branch>")\`
 
-6. **Cleanup**:
-   - Switch back to the original branch captured in step 1: `git checkout <original-branch>`.
+6. **Cleanup (MANDATORY)**:
+   - Switch back to the original branch captured in step 1: \`git checkout <original-branch>\`.
 
 7. **Completion**:
    - Inform the user that the PR has been created and you have switched back to the original branch.


### PR DESCRIPTION
## 📝 Summary
This PR updates the `commit-and-pr` skill to include a mandatory cleanup step, ensuring the agent always switches back to the original branch after creating a Pull Request.

## 🚀 Key Features / Changes
- Added a 'Mandatory Constraint' section.
- Marked the Cleanup step as MANDATORY.
- Included instructions to capture the current branch at the start.

## 🔍 Description
Previously, the agent might forget to switch back to the original branch after completing a PR, leading to an inconsistent workspace. This update makes the restoration of the original branch a non-negotiable step in the process.