### PR TITLE
fix(wechat): remove redundant cloud mode instances loading

### DIFF
--- a/src/lib/components/buss/open-claw-config-panel/channel/wechat/cloud-channel-service.svelte.ts
+++ b/src/lib/components/buss/open-claw-config-panel/channel/wechat/cloud-channel-service.svelte.ts
@@ -18,10 +18,6 @@ class CloudChannelService implements ChannelService {
 	});
 	fetchController: AbortController | null = null;
 
-	constructor() {
-		cloudModeState.loadInstances();
-	}
-
 	private messageFn: ((event: OpenClawWeixinLoginMsg) => void) | null = null;
 
 	async isInstalled(): Promise<boolean> {


### PR DESCRIPTION
## 📝 Summary

Removed redundant `cloudModeState.loadInstances()` call from `CloudChannelService` constructor.

## 🚀 Key Features / Changes

### 🛠 Refactoring / Fixes (if any)

- Removed unnecessary initialization in `CloudChannelService` constructor to prevent double loading or improper state initialization timing.

## 🔍 Description

The `cloudModeState.loadInstances()` call was being executed in the `CloudChannelService` constructor. This is often redundant if the state is managed elsewhere or if the service is instantiated before the necessary environment is ready.

## 🧪 Test Plan

- [x] **Quality Gates**: Ran `pnpm quality` (verified during commit hooks)
- [x] **Manual Testing**:
    - [x] Verified that the removal doesn't affect the basic functionality of the WeChat channel service.
- [x] **Regressions**: Confirmed no breaking changes or regressions.

## 📂 Files Changed

- `src/lib/components/buss/open-claw-config-panel/channel/wechat/cloud-channel-service.svelte.ts`: Removed the constructor.