### PR TITLE
chore(env): remove hardcoded VITE_TEST_API_URL in example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 # Example environment file
 # Define the URL for testing
-VITE_TEST_API_URL=http://192.168.199.65:8001
+VITE_TEST_API_URL=


### PR DESCRIPTION
## 📝 Summary

- Cleaned up .env.example by removing a hardcoded test API URL.

## 🚀 Key Features / Changes

### 🧹 Chore / Others

- Replaced hardcoded IP in `VITE_TEST_API_URL` with an empty value in `.env.example`.

## 🔍 Description

The example environment file contained a specific local IP address which could be confusing or leak internal configuration. It's better to keep it empty for users to fill in.

## 🧪 Test Plan

- [x] **Quality Gates**: Ran `pnpm quality` (lint, format, type-check) and passed
- [x] **Manual Testing**: Verified file content locally.
