### PR TITLE
fix(code-agent): correct cloud mode confirm handler and state integration

### DIFF
--- a/src/routes/(with-sidebar)/chat/components/code-agent/cloud-mode-panel.svelte
+++ b/src/routes/(with-sidebar)/chat/components/code-agent/cloud-mode-panel.svelte
@@ -12,10 +12,12 @@
 	import { Button } from "$lib/components/ui/button";
 	import { Label } from "$lib/components/ui/label";
 	import { m } from "$lib/paraglide/messages";
+	import { codeAgentState } from "$lib/stores/code-agent/code-agent-state.svelte";
 
 	let { onClose }: Props = $props();
 
-	function handleLocalModeConfirm() {
+	function handleCloudModeConfirm() {
+		codeAgentState.handleConfirmEnabled();
 		onClose?.();
 	}
 </script>
@@ -38,7 +40,7 @@
 		<Button variant="secondary" onclick={onClose}>
 			{m.common_cancel()}
 		</Button>
-		<Button onclick={handleLocalModeConfirm}>
+		<Button onclick={handleCloudModeConfirm}>
 			{m.label_button_confirm()}
 		</Button>
 	</div>


### PR DESCRIPTION
## 📝 Summary

Corrected the function name from `handleLocalModeConfirm` to `handleCloudModeConfirm` in the cloud mode panel and integrated it with `codeAgentState` to properly handle the confirmation state.

## 🚀 Key Features / Changes

### 🛠 Refactoring / Fixes

- Renamed `handleLocalModeConfirm` to `handleCloudModeConfirm` to reflect the actual panel context.
- Integrated `codeAgentState.handleConfirmEnabled()` to trigger the necessary state transition when confirming cloud mode.
- Fixed the button `onclick` handler to point to the correct function.

## 🔍 Description

The cloud mode panel was erroneously using a function named 'LocalMode', which was also lacking the state integration required to actually enable the cloud mode agent. This PR fixes both the naming and the logic.

## 🧪 Test Plan

- [x] **Quality Gates**: Ran `pnpm quality` (lint, format, type-check) and passed
- [x] **Manual Testing**:
    - [x] Verified that clicking 'Confirm' in the Cloud Mode panel now triggers the correct state change.
- [x] **Regressions**: Confirmed no breaking changes or regressions

## 📂 Files Changed

- `src/routes/(with-sidebar)/chat/components/code-agent/cloud-mode-panel.svelte`: Renamed handler and added state call.